### PR TITLE
fixed gtk-critical message when clicked on pathbar filler-widget  -- #27

### DIFF
--- a/thunar/thunar-location-bar.c
+++ b/thunar/thunar-location-bar.c
@@ -43,6 +43,9 @@ struct _ThunarLocationBar
   GtkBin __parent__;
 
   ThunarFile *current_directory;
+
+  GtkWidget  *locationEntry;
+  GtkWidget  *locationButtons;
 };
 
 
@@ -55,6 +58,7 @@ enum
 
 
 static void         thunar_location_bar_navigator_init             (ThunarNavigatorIface *iface);
+static void         thunar_location_bar_finalize                   (GObject              *object);
 static void         thunar_location_bar_get_property               (GObject              *object,
                                                                     guint                 prop_id,
                                                                     GValue               *value,
@@ -95,6 +99,7 @@ thunar_location_bar_class_init (ThunarLocationBarClass *klass)
 
   gobject_class->get_property = thunar_location_bar_get_property;
   gobject_class->set_property = thunar_location_bar_set_property;
+  gobject_class->finalize = thunar_location_bar_finalize;
 
   klass->reload_requested = exo_noop;
 
@@ -141,10 +146,32 @@ thunar_location_bar_init (ThunarLocationBar *bar)
   ThunarPreferences *preferences = thunar_preferences_get ();
 
   bar->current_directory = NULL;
+  bar->locationEntry = NULL;
+  bar->locationButtons = NULL;
 
   thunar_location_bar_settings_changed (bar);
 
   g_signal_connect_object (preferences, "notify::last-location-bar", G_CALLBACK (thunar_location_bar_settings_changed), bar, G_CONNECT_SWAPPED);
+}
+
+
+
+static void
+thunar_location_bar_finalize (GObject *object)
+{
+  ThunarLocationBar *bar = THUNAR_LOCATION_BAR (object);
+
+  _thunar_return_if_fail (THUNAR_IS_LOCATION_BAR (bar));
+
+  if (bar->locationEntry)
+    g_object_unref (bar->locationEntry);
+  if (bar->locationButtons)
+    g_object_unref (bar->locationButtons);
+
+  /* release from the current_directory */
+  thunar_navigator_set_current_directory (THUNAR_NAVIGATOR (bar), NULL);
+
+  (*G_OBJECT_CLASS (thunar_location_bar_parent_class)->finalize) (object);
 }
 
 
@@ -237,34 +264,46 @@ static GtkWidget *
 thunar_location_bar_install_widget (ThunarLocationBar    *bar,
                                     GType                 type)
 {
-  GtkWidget *widget, *child;
+  GtkWidget *installedWidget, *child;
 
   /* check if the the right type is already installed */
   if ((child = gtk_bin_get_child (GTK_BIN (bar))) && G_TYPE_CHECK_INSTANCE_TYPE (child, type))
     return child;
 
-  widget = gtk_widget_new (type, "current-directory", bar->current_directory, NULL);
-
-  /* forward signals */
-  g_signal_connect_swapped (widget, "change-directory", G_CALLBACK (thunar_navigator_change_directory), THUNAR_NAVIGATOR (bar));
-  g_signal_connect_swapped (widget, "open-new-tab", G_CALLBACK (thunar_navigator_open_new_tab), THUNAR_NAVIGATOR (bar));
-
   if (type == THUNAR_TYPE_LOCATION_ENTRY)
     {
-      g_signal_connect_swapped (widget, "reload-requested", G_CALLBACK (thunar_location_bar_reload_requested), bar);
+    if (bar->locationEntry == NULL)
+      {
+      bar->locationEntry = gtk_widget_new (THUNAR_TYPE_LOCATION_ENTRY, "current-directory", NULL, NULL);
+      g_object_ref (bar->locationEntry);
+      g_signal_connect_swapped (bar->locationEntry, "reload-requested", G_CALLBACK (thunar_location_bar_reload_requested), bar);
+      g_signal_connect_swapped (bar->locationEntry, "change-directory", G_CALLBACK (thunar_navigator_change_directory), THUNAR_NAVIGATOR (bar));
+      g_signal_connect_swapped (bar->locationEntry, "open-new-tab", G_CALLBACK (thunar_navigator_open_new_tab), THUNAR_NAVIGATOR (bar));
+      }
+    installedWidget = bar->locationEntry;
     }
-  else if (type == THUNAR_TYPE_LOCATION_BUTTONS)
+  else
     {
-      g_signal_connect_swapped (widget, "entry-requested", G_CALLBACK (thunar_location_bar_request_entry), bar);
+    if (bar->locationButtons == NULL)
+      {
+      bar->locationButtons = gtk_widget_new (THUNAR_TYPE_LOCATION_BUTTONS, "current-directory", NULL, NULL);
+      g_object_ref (bar->locationButtons);
+      g_signal_connect_swapped (bar->locationButtons, "entry-requested", G_CALLBACK (thunar_location_bar_request_entry), bar);
+      g_signal_connect_swapped (bar->locationButtons, "change-directory", G_CALLBACK (thunar_navigator_change_directory), THUNAR_NAVIGATOR (bar));
+      g_signal_connect_swapped (bar->locationButtons, "open-new-tab", G_CALLBACK (thunar_navigator_open_new_tab), THUNAR_NAVIGATOR (bar));
+      }
+    installedWidget = bar->locationButtons;
     }
+
+  thunar_navigator_set_current_directory (THUNAR_NAVIGATOR (installedWidget), bar->current_directory);
 
   if ((child = gtk_bin_get_child (GTK_BIN (bar))))
-    gtk_widget_destroy (child);
+    gtk_container_remove (GTK_CONTAINER (bar), child);
 
-  gtk_container_add (GTK_CONTAINER (bar), widget);
-  gtk_widget_show (widget);
+  gtk_container_add (GTK_CONTAINER (bar), installedWidget);
+  gtk_widget_show (installedWidget);
 
-  return widget;
+  return installedWidget;
 }
 
 

--- a/thunar/thunar-location-buttons.c
+++ b/thunar/thunar-location-buttons.c
@@ -400,8 +400,8 @@ thunar_location_buttons_set_current_directory (ThunarNavigator *navigator,
   ThunarLocationButtons *buttons = THUNAR_LOCATION_BUTTONS (navigator);
   ThunarFile            *file_parent;
   ThunarFile            *file;
-  GtkWidget             *button, *parent_button = NULL;
-  GList                 *lp, *lp_parent = NULL;
+  GtkWidget             *button;
+  GList                 *lp;
 
   _thunar_return_if_fail (current_directory == NULL || THUNAR_IS_FILE (current_directory));
 
@@ -411,97 +411,53 @@ thunar_location_buttons_set_current_directory (ThunarNavigator *navigator,
 
   /* check if we already have a button for that directory */
   for (lp = buttons->list; lp != NULL; lp = lp->next)
+    {
     if (thunar_location_button_get_file (lp->data) == current_directory)
-      break;
-
-  /* check if we maybe have the parent as a button */
-  if (!lp && current_directory)
-    {
-      file_parent = thunar_file_get_parent (current_directory, NULL);
-      if (file_parent)
-        {
-            for (lp_parent = buttons->list; lp_parent != NULL; lp_parent = lp_parent->next)
-                if (thunar_location_button_get_file (lp_parent->data) == file_parent)
-                break;
-
-            g_object_unref (file_parent);
-        }
-    }
-
-  /* if we already have a button for that directory, just activate it */
-  if (G_UNLIKELY (lp != NULL))
-    {
+      {
       /* fake a "clicked" event for that button */
       gtk_button_clicked (GTK_BUTTON (lp->data));
+      return;
+      }
     }
-  else if (G_LIKELY (lp_parent != NULL))
+
+  if (G_LIKELY (buttons->current_directory != NULL))
     {
-      /* remove all existing children below that button */
-      parent_button = lp_parent->data;
-      while (buttons->list->data != parent_button)
-        gtk_container_remove (GTK_CONTAINER (buttons), buttons->list->data);
+    /* remove all buttons */
+    g_object_unref (G_OBJECT (buttons->current_directory));
 
-      /* clear the first scrolled button */
-      buttons->first_scrolled_button = NULL;
+    while (buttons->list != NULL)
+      gtk_container_remove (GTK_CONTAINER (buttons), buttons->list->data);
 
-      /* set the new directory */
-      g_object_unref (buttons->current_directory);
-      buttons->current_directory = g_object_ref (current_directory);
-
-      /* add a new button */
-      button = thunar_location_buttons_make_button (buttons, current_directory);
-      buttons->list = g_list_prepend (buttons->list, button);
-      gtk_container_add (GTK_CONTAINER (buttons), button);
-      gtk_widget_show (button);
-
-      /* check for fake root */
-      if (eglible_for_fake_root (current_directory))
-        buttons->fake_root_button = buttons->list;
-
-      /* synthesize a click */
-      gtk_button_clicked (GTK_BUTTON (buttons->list->data));
+    /* clear the first scrolled and fake root buttons */
+    buttons->first_scrolled_button = NULL;
+    buttons->fake_root_button = NULL;
     }
-  else
+
+  buttons->current_directory = current_directory;
+
+  /* regenerate the button list */
+  if (G_LIKELY (current_directory != NULL))
     {
-      /* regenerate the button list */
-      if (G_LIKELY (buttons->current_directory != NULL))
-        {
-          g_object_unref (G_OBJECT (buttons->current_directory));
+    g_object_ref (G_OBJECT (current_directory));
 
-          /* remove all buttons */
-          while (buttons->list != NULL)
-            gtk_container_remove (GTK_CONTAINER (buttons), buttons->list->data);
+    /* add the new buttons */
+    for (file = current_directory; file != NULL; file = file_parent)
+      {
+        button = thunar_location_buttons_make_button (buttons, file);
+        buttons->list = g_list_append (buttons->list, button);
+        gtk_container_add (GTK_CONTAINER (buttons), button);
+        gtk_widget_show (button);
 
-          /* clear the first scrolled and fake root buttons */
-          buttons->first_scrolled_button = NULL;
-          buttons->fake_root_button = NULL;
-        }
+        /* use 'Home' as fake root button */
+        if (!buttons->fake_root_button && eglible_for_fake_root (file))
+          buttons->fake_root_button = g_list_last (buttons->list);
 
-      buttons->current_directory = current_directory;
+        /* continue with the parent (if any) */
+        file_parent = thunar_file_get_parent (file, NULL);
 
-      if (G_LIKELY (current_directory != NULL))
-        {
-          g_object_ref (G_OBJECT (current_directory));
-
-          /* add the new buttons */
-          for (file = current_directory; file != NULL; file = file_parent)
-            {
-              button = thunar_location_buttons_make_button (buttons, file);
-              buttons->list = g_list_append (buttons->list, button);
-              gtk_container_add (GTK_CONTAINER (buttons), button);
-              gtk_widget_show (button);
-
-              /* use 'Home' as fake root button */
-              if (!buttons->fake_root_button && eglible_for_fake_root (file))
-                buttons->fake_root_button = g_list_last (buttons->list);
-
-              /* continue with the parent (if any) */
-              file_parent = thunar_file_get_parent (file, NULL);
-
-              if (G_LIKELY (file != current_directory))
-                g_object_unref (G_OBJECT (file));
-            }
-        }
+        if (G_LIKELY (file != current_directory))
+          g_object_unref (G_OBJECT (file));
+      }
     }
 
   g_object_notify (G_OBJECT (buttons), "current-directory");


### PR DESCRIPTION
.... this time some more code-changes. ... probably I should explain all the changes:
thunar/thunar-location-bar.c:
- location-entry/location-buttons now are only created once in init of location-bar, ref to both is stored in location-Bar. They are only removed/added to the location-bar-bin-container on need now.
- finalize needed now to unref them on destroy
- extra include "thunar-private.h" needed for _thunar_return_if_fail in finalize

thunar/thunar-location-buttons.c:
- The changes in thunar-location-bar.c created a seg-fault when switching (via pathbar-edit) to a directory-root which is not part of $HOME ( e.g. /etc )
- This seg-fault did not show up before, since before the whole location-buttons-object always was destroyed/rebuild when clicked on "edit"
- Source of the problem:  "/etc" has no  "fake-root button" like "$HOME" .. the full path is shown there.
- Problem fixed by removing unneeded, incomplete optimization ( the block below /* check if we maybe have the parent as a button */  ... ) ... now all buttons are re-build in that case
- removed a if/else which got obsolete by that and fixed indention


