### PR TITLE
Rewrite menus to GtkBuilder format

### DIFF
--- a/thunar/Makefile.am
+++ b/thunar/Makefile.am
@@ -37,6 +37,7 @@ thunar_built_sources =							\
 	thunar-thumbnailer-proxy.h					\
 	thunar-thumbnail-cache-proxy.h 					\
 	thunar-thumbnail-cache-proxy.c					\
+	thunar-window-menus-ui.h					\
 	thunar-window-ui.h
 
 
@@ -315,6 +316,9 @@ thunar-renamer-dialog-ui.h: Makefile $(srcdir)/thunar-renamer-dialog-ui.xml
 
 thunar-standard-view-ui.h: Makefile $(srcdir)/thunar-standard-view-ui.xml
 	$(AM_V_GEN) exo-csource --strip-comments --strip-content --static --name=thunar_standard_view_ui $(srcdir)/thunar-standard-view-ui.xml > thunar-standard-view-ui.h
+
+thunar-window-menus-ui.h: Makefile $(srcdir)/thunar-window-menus.ui
+	$(AM_V_GEN) exo-csource --strip-comments --strip-content --static --name=thunar_window_menus_ui $(srcdir)/thunar-window-menus.ui > thunar-window-menus-ui.h
 
 thunar-window-ui.h: Makefile $(srcdir)/thunar-window-ui.xml
 	$(AM_V_GEN) exo-csource --strip-comments --strip-content --static --name=thunar_window_ui $(srcdir)/thunar-window-ui.xml > thunar-window-ui.h

--- a/thunar/thunar-window-menus.ui
+++ b/thunar/thunar-window-menus.ui
@@ -33,7 +33,7 @@
 								<property name="always-show-image">True</property>
 								<property name="action-name">win.new-tab</property>
 								<!--tooltip-->
-								<property name="tooltip-text">Open a new tab for the displayed location</property>
+								<property translatable="yes" name="tooltip-text">Open a new tab for the displayed location</property>
 								<property name="has-tooltip">False</property>
 								<signal name="select" handler="menu-item-selected" swapped="no"/>
 								<signal name="deselect" handler="menu-item-deselected" swapped="no"/>
@@ -50,7 +50,7 @@
 								<property name="always-show-image">True</property>
 								<property name="action-name">win.new-window</property>
 								<!--tooltip-->
-								<property name="tooltip-text">Open a new Thunar window for the displayed location</property>
+								<property translatable="yes" name="tooltip-text">Open a new Thunar window for the displayed location</property>
 								<property name="has-tooltip">False</property>
 								<signal name="select" handler="menu-item-selected" swapped="no"/>
 								<signal name="deselect" handler="menu-item-deselected" swapped="no"/>

--- a/thunar/thunar-window-menus.ui
+++ b/thunar/thunar-window-menus.ui
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+	<!--WIP!-->
+
+	<requires lib="gtk+" version="3.20"/>
+
+	<object class="GtkAccelGroup" id="accel-group"/>
+
+	<object class="GtkMenuBar" id="main-menu">
+		<property name="visible">True</property>
+		<property name="can_focus">False</property>
+		<child>
+			<!--File-->
+			<object class="GtkMenuItem">
+				<property name="label" translatable="yes">_File</property>
+				<property name="visible">True</property>
+				<property name="can_focus">False</property>
+				<property name="use_underline">True</property>
+				<child type="submenu">
+					<object class="GtkMenu">
+						<property name="visible">True</property>
+						<property name="can_focus">False</property>
+						<property name="accel_group">accel-group</property>
+						<property name="accel_path">&lt;ThunarWindow&gt;/File</property>
+						<!--New Tab-->
+						<child>
+							<object class="GtkImageMenuItem">
+								<property name="label" translatable="yes">New _Tab</property>
+								<property name="image">new-tab-image</property>
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<property name="use_underline">True</property>
+								<property name="always-show-image">True</property>
+								<property name="action-name">win.new-tab</property>
+								<!--tooltip-->
+								<property name="tooltip-text">Open a new tab for the displayed location</property>
+								<property name="has-tooltip">False</property>
+								<signal name="select" handler="menu-item-selected" swapped="no"/>
+								<signal name="deselect" handler="menu-item-deselected" swapped="no"/>
+							</object>
+						</child>
+						<!--New Window-->
+						<child>
+							<object class="GtkImageMenuItem">
+								<property name="label" translatable="yes">New _Window</property>
+								<property name="image">new-window-image</property>
+								<property name="visible">True</property>
+								<property name="can_focus">False</property>
+								<property name="use_underline">True</property>
+								<property name="always-show-image">True</property>
+								<property name="action-name">win.new-window</property>
+								<!--tooltip-->
+								<property name="tooltip-text">Open a new Thunar window for the displayed location</property>
+								<property name="has-tooltip">False</property>
+								<signal name="select" handler="menu-item-selected" swapped="no"/>
+								<signal name="deselect" handler="menu-item-deselected" swapped="no"/>
+							</object>
+						</child>
+					</object>
+				</child>
+			</object>
+		</child>
+	</object>
+
+	<object class="GtkImage" id="new-tab-image">
+		<property name="visible">True</property>
+		<property name="icon-name">tab-new</property>
+	</object>
+	<object class="GtkImage" id="new-window-image">
+		<property name="visible">True</property>
+		<property name="icon-name">window-new</property>
+	</object>
+
+</interface>

--- a/thunar/thunar-window.c
+++ b/thunar/thunar-window.c
@@ -59,6 +59,7 @@
 #include <thunar/thunar-trash-action.h>
 #include <thunar/thunar-tree-pane.h>
 #include <thunar/thunar-window.h>
+#include <thunar/thunar-window-menus-ui.h>
 #include <thunar/thunar-window-ui.h>
 #include <thunar/thunar-device-monitor.h>
 


### PR DESCRIPTION
First two patches to show the way.

UI file is now less clean than it was but we're in a workaround mode when gtk menu items are not supporting icons any more. If a custom Xfce widget for gtk menu item will be added later, transition will be easy.
Other parts of the code are dealing with deprecated functions and are all related to UI rewrite.
