### PR TITLE
fixes 8 second delay on logout when thunar got started in daemon mode

### DIFF
--- a/thunar/thunar-application.c
+++ b/thunar/thunar-application.c
@@ -114,7 +114,7 @@ static void           thunar_application_set_property           (GObject        
 static void           thunar_application_startup                (GApplication           *application);
 static void           thunar_application_shutdown               (GApplication           *application);
 static void           thunar_application_activate               (GApplication           *application);
-static void           thunar_application_handle_hangup_signal   (int                     signal);
+static void           thunar_application_handle_hangup_signal   (ThunarApplication      *application);
 static int            thunar_application_handle_local_options   (GApplication           *application,
                                                                  GVariantDict           *options);
 static int            thunar_application_command_line           (GApplication           *application,
@@ -271,7 +271,7 @@ thunar_application_init (ThunarApplication *application)
   application->preferences     = NULL;
 
   /* required in order to have a clean thunar_application_shutdown on session-logout in daemon-mode */
-  signal(SIGHUP, thunar_application_handle_hangup_signal);
+  g_unix_signal_add (SIGHUP, thunar_application_handle_hangup_signal, application);
 
   g_application_set_flags (G_APPLICATION (application), G_APPLICATION_HANDLES_COMMAND_LINE);
   g_application_add_main_option_entries (G_APPLICATION (application), option_entries);
@@ -419,10 +419,8 @@ thunar_application_finalize (GObject *object)
 
 
 static void
-thunar_application_handle_hangup_signal (int signal)
+thunar_application_handle_hangup_signal (ThunarApplication *application)
 {
-  ThunarApplication     *application = thunar_application_get ();
-
   thunar_application_set_daemon (application, FALSE);
 }
 

--- a/thunar/thunar-application.c
+++ b/thunar/thunar-application.c
@@ -114,6 +114,7 @@ static void           thunar_application_set_property           (GObject        
 static void           thunar_application_startup                (GApplication           *application);
 static void           thunar_application_shutdown               (GApplication           *application);
 static void           thunar_application_activate               (GApplication           *application);
+static void           thunar_application_handle_hangup_signal   (int                     signal);
 static int            thunar_application_handle_local_options   (GApplication           *application,
                                                                  GVariantDict           *options);
 static int            thunar_application_command_line           (GApplication           *application,
@@ -269,6 +270,9 @@ thunar_application_init (ThunarApplication *application)
   application->progress_dialog = NULL;
   application->preferences     = NULL;
 
+  /* required in order to have a clean thunar_application_shutdown on session-logout in daemon-mode */
+  signal(SIGHUP, thunar_application_handle_hangup_signal);
+
   g_application_set_flags (G_APPLICATION (application), G_APPLICATION_HANDLES_COMMAND_LINE);
   g_application_add_main_option_entries (G_APPLICATION (application), option_entries);
 }
@@ -410,6 +414,16 @@ thunar_application_finalize (GObject *object)
    * in GApplication::shutdown. Therefore, this method doesn't do very much */
 
   (*G_OBJECT_CLASS (thunar_application_parent_class)->finalize) (object);
+}
+
+
+
+static void
+thunar_application_handle_hangup_signal (int signal)
+{
+  ThunarApplication     *application = thunar_application_get ();
+
+  thunar_application_set_daemon (application, FALSE);
 }
 
 


### PR DESCRIPTION
fixes #30 
Before merge,  I would like to check if there are other possibilities to handle logout on g_application_hold()  ... just created some [Stack-Overflow Question](https://stackoverflow.com/questions/44913967/gtk3-logout-during-g-application-hold)

I could check for Error on line 274 ... but actually I dont know to where I should write an error in thunar, if one appears .. you have any idea ?



